### PR TITLE
Fix power-up duration handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@
           ellipse(spawnPowerUp.x, spawnPowerUp.y, POWER_UP_RADIUS * 2);
           if (isClapping && dist(spawnPowerUp.x, spawnPowerUp.y, handX, handY) < POWER_UP_RADIUS + 10) {
             activePowerUp = spawnPowerUp;
-            activeEndsAt = now + Math.min(activePowerUp.duration, 5) * 1000;
+            activeEndsAt = now + activePowerUp.duration * 1000;
             scoreMultiplier = multiplierForTier(activePowerUp.tier);
             spawnPowerUp = null;
           }


### PR DESCRIPTION
## Summary
- ensure power-up lasts for its full specified duration instead of capping at 5 seconds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689217a18cf88324a507682fd50e9401